### PR TITLE
（保留）依存関係のプリビルドによるコンパイル時間短縮

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,6 @@ Dockerfile
 # others
 README.md
 .DS_Store
+　
+# Rust
+target

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 down:
 	docker compose down -v
 
+network:
+	docker network create devtrackr-network
+
+prune:
+	docker system prune --force
+
 build:
 	docker compose build
 
-build-no-cache:
+build-n:
 	docker compose build --no-cache
 
 up:
@@ -18,6 +24,13 @@ re:
 re-n:
 	make down
 	make build-no-cache
+	make up
+
+re-all-force:
+	make down
+	make prune
+	make network
+	make build-n
 	make up
 
 container=frontend

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -2,6 +2,19 @@ FROM rust:1.80-slim-bullseye
 
 WORKDIR /usr/src/app
 
+# プロジェクトの依存関係のみをコピー
+COPY Cargo.toml Cargo.lock ./
+
+# この時点ではコードがイメージ内に存在しないため、ダミーソースコードを用いて依存関係のプリビルドを行う（最も時間がかかる部分）
+RUN mkdir src && \
+    echo "fn main() {}" > src/main.rs && \
+    cargo build && \
+    rm -rf src
+
+# cargo-watchをインストール
 RUN cargo install cargo-watch
 
+# ホットリロード
 CMD ["cargo", "watch", "-x", "run"]
+
+# TODO: 本番環境用ではマルチステージビルド用のファイルを作成する.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,13 +34,14 @@ services:
     volumes:
       - ./backend:/usr/src/app
       - /usr/src/app/target
-      - cargo-cache:/usr/local/cargo/registry # コンテナbuildの結果をキャッシュしておく事でbuild時間を短縮
+      - cargo_cache:/usr/local/cargo/registry # コンテナbuildの結果をキャッシュしておく事でbuild時間を短縮
     networks:
       - devtrackr-network
     environment:
       - RUST_LOG=${RUST_LOG:-debug}
       - DATABASE_URL=mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongo:27018/${MONGO_INITDB_DATABASE}?authSource=admin
       - HOST=0.0.0.0
+      - CARGO_HOME=/usr/local/cargo/registry
     depends_on:
       mongo:
         condition: service_healthy
@@ -142,4 +143,4 @@ networks:
 
 volumes:
   mongodb_data:
-  cargo-cache:
+  cargo_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     volumes:
       - ./backend:/usr/src/app
       - /usr/src/app/target
+      - cargo-cache:/usr/local/cargo/registry # コンテナbuildの結果をキャッシュしておく事でbuild時間を短縮
     networks:
       - devtrackr-network
     environment:
@@ -141,3 +142,4 @@ networks:
 
 volumes:
   mongodb_data:
+  cargo-cache:


### PR DESCRIPTION
# 概要
backendのビルド時間が長いので短縮したい

# 詳細
make build時にbackendコンテナ内でコンパイル実行される。
その後make up時に再びコンパイルが行われており、起動に時間がかかっていた。

# 対策
以下によりコンパイルを分類し、ビルド時間を大きく短縮
## Dockerfile
1. 依存関係のみをコピー
2. ダミーのmain.rsを作成し、1の依存関係のみプリビルド
  （コンパイルに最も時間を食っていたのはこの部分）
3. ホットリロードで起動
  
## docker-compose.yml
- `cargo-cache`のボリュームを追加してマウント
　→ビルドキャッシュになる。前述2の結果はキャッシュされるので、コンテナ起動時にスキップ対象となる

# 動作確認
## 修正前
![image](https://github.com/user-attachments/assets/07079edc-4426-4145-a860-d49cf311ed54)
コンテナ起動後↓
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/2c83db0d-b258-404d-a9fd-b51abc1e6b1a">

## 修正後
![image](https://github.com/user-attachments/assets/1223b1c3-ae99-4aae-92f0-a643cf531dd6)
コンテナ起動完了後のコンパイル時間↓
<img width="1181" alt="image" src="https://github.com/user-attachments/assets/38dd4825-74ee-4241-a4c8-f0beccbdc3d8">
 
# メモ
- ダミーファイルによるプリビルドのメリット
  - 開発時のコンテナ起動時間を短縮できる。
  - ホットリロードと組み合わせることで、開発効率を向上できる。

- マルチステージビルドのメリット
  - 最終的なイメージサイズを大幅に削減できる。
  - セキュリティリスクを軽減できる（不要なツールや依存関係を含めないため）。
  - 本番環境へのデプロイに適している。

# TODO
- 本番環境用にDockerfileを作成しておく
→マルチステージビルドを駆使